### PR TITLE
Renderのホストを許可

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,8 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
+  config.hosts << "live-tour-memory.onrender.com"
+
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
Renderの公開URLへアクセスした際にBlocked hostsエラーが発生したため、production.rb に Renderのホストを追加。