### PR TITLE
本番環境でアセットをプリコンパイル

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN bundle install
 
 COPY . /app
 
+RUN RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+
 ENTRYPOINT ["/app/bin/docker-entrypoint"]
 
 CMD ["./bin/rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
## 概要

Renderの本番環境で画像アセットが読み込めず、TOPページでエラーが発生していたため、デプロイ時にアセットをプリコンパイルする設定を追加しました。

## 変更内容

- Dockerイメージのビルド時に `assets:precompile` を実行するように変更
- 本番環境で画像やCSSなどのアセットを利用できるように設定

## 確認内容

- ローカルのDocker環境で `assets:precompile` が正常に完了することを確認
- `hero-travel.png` が `public/assets` に生成されることを確認
- `docker compose build` が正常に完了することを確認

## 今後の対応

- Renderへ再デプロイ
- 公開URLでTOPページが正常に表示されることを確認